### PR TITLE
Ajout limite et premium aux giveaways

### DIFF
--- a/docs/2.modules/27.giveaways.md
+++ b/docs/2.modules/27.giveaways.md
@@ -26,6 +26,10 @@ Vous pouvez créer un giveaway avec les commandes \</concours créer>. Suivant c
   Une fois le giveaway terminé, le créateur reçoit un message privé de <@DraftBot> l'informant du gagnant et lui rappelant la récompense.
 ::
 
+::hint{ type="info" }
+  Vous pouvez lancer jusqu'à 3 giveaways en simultané avec l'offre gratuite de DraftBot. L'[offre Premium](/premium) <:icon_premium_:1096140508625125417> vous permet d'en avoir un nombre illimité.
+::
+
 ## Gérer les giveaways
 
 Une fois que vous avez créé un giveaway, vous pouvez le gérer avec plusieurs commandes :

--- a/docs/2.modules/27.giveaways.md
+++ b/docs/2.modules/27.giveaways.md
@@ -27,7 +27,7 @@ Vous pouvez créer un giveaway avec les commandes \</concours créer>. Suivant c
 ::
 
 ::hint{ type="info" }
-  Vous pouvez lancer jusqu'à 3 giveaways en simultané avec l'offre gratuite de DraftBot. L'[offre Premium](/premium) <:icon_premium_:1096140508625125417> vous permet d'en avoir un nombre illimité.
+  Vous pouvez lancer jusqu'à 3 giveaways en simultané. Les serveurs [premium](/premium) <:icon_premium_:1096140508625125417> n'ont pas de limite.
 ::
 
 ## Gérer les giveaways


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page giveaways.md](https://preview.draftbot.fr?pr=146&file=docs%2F2.modules%2F27.giveaways.md)

## 📝 Résumé des modifications
Le fichier markdown `docs/2.modules/27.giveaways.md` a été modifié. Les changements incluent :

- Ajout d'une section d'information indiquant que l'utilisateur peut lancer jusqu'à 3 giveaways en même temps grâce à l'offre gratuite de DraftBot, et que l'offre Premium permet d'en avoir un nombre illimité.
- Aucune modification des sections concernant la création et la gestion des giveaways.