### PR TITLE
Ajout de compteur-de-membre

### DIFF
--- a/docs/2.modules/28.compteur-de-membre.md
+++ b/docs/2.modules/28.compteur-de-membre.md
@@ -1,7 +1,8 @@
 ---
-title: compteur-de-membre
-description:
-navigation.icon: 'twemoji:memo'
+title: Salons statistiques
+description: Affichez des statistiques liée à votre serveur de manière automatisé !
+navigation.icon: 'twemoji:abacus'
 contributors: ['titoto289']
 updated_at: '2025-03-23'
 ---
+

--- a/docs/2.modules/28.compteur-de-membre.md
+++ b/docs/2.modules/28.compteur-de-membre.md
@@ -1,0 +1,7 @@
+---
+title: compteur-de-membre
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['titoto289']
+updated_at: '2025-03-23'
+---


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page compteur-de-membre.md](https://preview.draftbot.fr?pr=147&file=docs%2F2.modules%2F28.compteur-de-membre.md)

## 📝 Résumé des modifications
Le fichier markdown `docs/2.modules/28.compteur-de-membre.md` a été ajouté avec les modifications suivantes :

- Titre : Salons statistiques
- Description : Affiche les statistiques liées à votre serveur de manière automatique !
- Icône de navigation : un abacus (twemoji :abacus)
- Contributeurs : titoto289
- Date de mise à jour : 2025-03-23

Ces modifications ont été apportées dans un nouveau fichier, il n'y a pas de changements dans un fichier existant.