### PR TITLE
clarification sur comment mentionner des rôles et des membres

### DIFF
--- a/docs/3.autres/0.recuperer-un-identifiant.md
+++ b/docs/3.autres/0.recuperer-un-identifiant.md
@@ -2,7 +2,7 @@
 title: Récupérer un identifiant
 description: Chaque message, rôle, membre, serveur et émoji dispose d'un identifiant qui leur est unique. Il peut être utile pour la configuration de certains modules.
 navigation.icon: 'material-symbols:filter-none-outline'
-contributors: ['hugo-broc', 'sagipierre']
+contributors: ['hugo-broc', 'sagipierre', 'titoto289']
 updatedAt: '2022-09-06'
 ---
 
@@ -34,7 +34,7 @@ Afin de récupérer l'identifiant d'un rôle, vous devez :
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un rôle](../assets/autres/role_id.gif)
 
-Si vous avez besoin de mentionner un rôle (ex: panel web), il vous suffit de faire <@\&ID-Role>
+Si vous avez besoin de mentionner un rôle (ex: panel web), il vous suffit de faire `<@&[ID-Role]>`
 
 ## Identifiant d'un membre
 
@@ -50,7 +50,7 @@ Pour récupérer l'identifiant d'un membre, vous devez :
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un membre](../assets/autres/member_id.gif)
 
-Si vous avez besoin de mentionner un membre (ex: panel web), vous pouvez écrire <@ID-Membre>
+Si vous avez besoin de mentionner un membre (ex: panel web), vous pouvez écrire `<@[ID-Membre]>`
 
 ## Identifiant d'un émoji
 
@@ -58,8 +58,6 @@ Pour obtenir l'identifiant d'un émoji, il vous suffit :&#x20;
 
 - D'écrire votre émoji dans un salon textuel
 - Avant l’émoji, mettez un antislash
-
-
 - Puis envoyez votre message.
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un émoji](../assets/autres/emoji_id.gif)
@@ -67,7 +65,7 @@ Pour obtenir l'identifiant d'un émoji, il vous suffit :&#x20;
 ::hint{ type="info" }
   Si vous êtes sur **Android**, pour récupérer l'identifiant d'un émoji :&#x20;
 
-  - Envoyez`` `:LeNomDeVotreEmoji:` `` dans un salon textuel
+  - Envoyez `:LeNomDeVotreEmoji:` dans un salon textuel
   - Puis copiez le résultat étant l'identifiant de l’émoji
 ::
 

--- a/docs/3.autres/0.recuperer-un-identifiant.md
+++ b/docs/3.autres/0.recuperer-un-identifiant.md
@@ -34,7 +34,7 @@ Afin de récupérer l'identifiant d'un rôle, vous devez :
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un rôle](../assets/autres/role_id.gif)
 
-Si vous avez besoin de mentionner un rôle (ex: panel web), il vous suffit de faire `<@&[ID-Role]>`
+Si vous avez besoin de mentionner un rôle (ex: panel web), il vous suffit de faire `<@&[ID-Role]>`.
 
 ## Identifiant d'un membre
 
@@ -50,7 +50,7 @@ Pour récupérer l'identifiant d'un membre, vous devez :
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un membre](../assets/autres/member_id.gif)
 
-Si vous avez besoin de mentionner un membre (ex: panel web), vous pouvez écrire `<@[ID-Membre]>`
+Si vous avez besoin de mentionner un membre (ex: panel web), vous pouvez écrire `<@[ID-Membre]>`.
 
 ## Identifiant d'un émoji
 


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page recuperer-un-identifiant.md](https://editor.draftbot.fr?pr=160&file=docs-autres-recuperer-un-identifiant.md)

## 📝 Résumé des modifications
Les changements apportés dans le fichier docs/3.autres/0.recuperer-un-identifiant.md consistent à ajouter un contributeur supplémentaire à la liste des contributeurs. En outre, une modification a été apportée à la façon de mentionner un rôle en utilisant des accolades au lieu de `&` pour les ID de rôle.