### PR TITLE
Correction de fautes d’orthographe/ frappe dans "Récupérer un identifiant"

### DIFF
--- a/docs/2.modules/14.reactions-de-mots.md
+++ b/docs/2.modules/14.reactions-de-mots.md
@@ -2,13 +2,13 @@
 title: Réactions de mots
 description: Faites réagir DraftBot à vos messages pour ne plus jamais vous sentir seul.
 navigation.icon: 'twemoji:eyes'
-contributors: ['tellvex', 'wapiti13', 'titoto289']
+contributors: ['tellvex', 'wapiti13', 'titoto289', 'theorik']
 updatedAt: '2025-03-23'
 ---
 
 ## À quoi sert-il ?
 
-Le système de réactions de mots fait réagir **DraftBot** à des messages qui commencent par un mot prédéfini avec une ou plusieurs réactions définie. Un aperçu du message est disponible ci-dessous :
+Le système de réactions de mots fait réagir **DraftBot** à des messages qui commencent par un mot prédéfini avec une ou plusieurs réactions définies. Un aperçu du message est disponible ci-dessous :
 
 ![Aperçu du système](../assets/reactions-de-mots/view_wordreact.jpg)
 
@@ -43,7 +43,7 @@ Le système de réactions de mots fait réagir **DraftBot** à des messages qui 
     ::
 
     ::hint{ type="info" }
-      Vous pouvez configurez jusqu'à 10 réactions de mots. Les serveurs [premium](/premium) <:icon_premium:1096140508625125417> n'ont pas de limites.
+      Vous pouvez configurer jusqu'à 10 réactions de mots. Les serveurs [premium](/premium) <:icon_premium:1096140508625125417> n'ont pas de limites.
     ::
 
     ### Supprimer des réactions de mots
@@ -56,7 +56,7 @@ Le système de réactions de mots fait réagir **DraftBot** à des messages qui 
 
     ### Restreindre les réactions
 
-    Vous avez la possibilité de déterminer les rôles et/ou salons qui ne ferons pas réagir DraftBot <:draftbot:816002768971759636>
+    Vous avez la possibilité de déterminer les rôles et/ou salons qui ne feront pas réagir DraftBot <:draftbot:816002768971759636>
 
     ### Réinitialiser le système
 
@@ -85,7 +85,7 @@ Le système de réactions de mots fait réagir **DraftBot** à des messages qui 
     ::
 
     ::hint{ type="info" }
-      Vous pouvez configurez jusqu'à 10 réactions de mots. Les serveurs [premium](/premium) <:icon_premium:1096140508625125417> n'ont pas de limites.
+      Vous pouvez configurer jusqu'à 10 réactions de mots. Les serveurs [premium](/premium) <:icon_premium:1096140508625125417> n'ont pas de limites.
     ::
 
     ### Modifier une réaction de mot
@@ -95,10 +95,10 @@ Le système de réactions de mots fait réagir **DraftBot** à des messages qui 
     ### Restreindre les réactions
 
     ![Restriction de rôle](../assets/reactions-de-mots/condition_de_role.png)
-    Vous avez la possibilité de déterminer les rôles et/ou salons qui ne ferons pas réagir DraftBot <:draftbot:816002768971759636>
+    Vous avez la possibilité de déterminer les rôles et/ou salons qui ne feront pas réagir DraftBot <:draftbot:816002768971759636>
 
     ::hint{ type="info" }
-      Vous pouvez également choisir que seul certains rôle font réagir le bot.
+      Vous pouvez également choisir que seuls certains rôles font réagir le bot.
     ::
 
     ### Supprimer une réaction de mot

--- a/docs/3.autres/0.recuperer-un-identifiant.md
+++ b/docs/3.autres/0.recuperer-un-identifiant.md
@@ -2,7 +2,7 @@
 title: Récupérer un identifiant
 description: Chaque message, rôle, membre, serveur et émoji dispose d'un identifiant qui leur est unique. Il peut être utile pour la configuration de certains modules.
 navigation.icon: 'material-symbols:filter-none-outline'
-contributors: ['hugo-broc', 'sagipierre', 'titoto289']
+contributors: ['hugo-broc', 'sagipierre', 'titoto289', 'theorik']
 updatedAt: '2022-09-06'
 ---
 
@@ -11,7 +11,7 @@ updatedAt: '2022-09-06'
 ::hint{ type="warning" }
   Il vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
 
-  Pour se faire, il vous suffit d'aller dans les paramètres utilisateurs, Apparence (iOS), Comportement (Android) ou Avancés (ordinateur) puis d'activer le mode développeur.
+  Pour ce faire, il vous suffit d'aller dans les paramètres utilisateurs, Apparence (iOS), Comportement (Android) ou Avancés (ordinateur) puis d'activer le mode développeur.
 ::
 
 Pour récupérer l'identifiant d'un message, vous devez :&#x20;
@@ -39,12 +39,12 @@ Si vous avez besoin de mentionner un rôle (ex: panel web), il vous suffit de fa
 ## Identifiant d'un membre
 
 ::hint{ type="warning" }
-  ll vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
+  Il vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
 ::
 
 Pour récupérer l'identifiant d'un membre, vous devez :
 
-- Faire clique droit/cliquer sur la personne dont vous souhaitez récupérer l'identifiant
+- Faire clic droit/cliquer sur la personne dont vous souhaitez récupérer l'identifiant
     - Si vous êtes sur smartphone, cliquez sur les trois petits points en haut à droite
 - Puis appuyez sur **Copier l'identifiant**.
 
@@ -72,12 +72,12 @@ Pour obtenir l'identifiant d'un émoji, il vous suffit :&#x20;
 ## Identifiant d'un salon
 
 ::hint{ type="warning" }
-  ll vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
+  Il vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
 ::
 
 Pour obtenir l'identifiant d'un salon, vous pouvez :&#x20;
 
-- Appuyer ou faire clique droit sur le nom d'un salon
+- Appuyer ou faire clic droit sur le nom d'un salon
 - Puis d'appuyer sur **Copier l'identifiant**.
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un salon](../assets/autres/channel_id.gif)
@@ -87,12 +87,12 @@ Si vous avez besoin de mentionner un salon (ex: panel web), vous devez mettre <#
 ## Identifiant d'un serveur
 
 ::hint{ type="warning" }
-  ll vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
+  Il vous faut au préalable activer le `mode développeur` pour récupérer des identifiants.
 ::
 
 Si vous souhaitez récupérer l'identifiant d'un serveur, il vous suffit :
 
-- De faire un clique droit ou appuyer sur l'image/nom du serveur
+- De faire un clic droit ou appuyer sur l'image/nom du serveur
 - Puis d'appuyer sur **Copier l'identifiant**.
 
 ![Exemple de récupération sur ordinateur de l'identifiant d'un serveur](../assets/autres/guild_id.gif)

--- a/docs/3.autres/1.changelog/0.2025.md
+++ b/docs/3.autres/1.changelog/0.2025.md
@@ -1,7 +1,7 @@
 ---
 title: 2025
 description: Voici la liste de tous les changements effectués, datés et décris en 2025.
-contributors: ['draftproducts', 'awakno']
+contributors: ['draftproducts', 'awakno', 'theorik']
 updatedAt: '2025-05-04'
 noindex: true
 ---
@@ -96,7 +96,7 @@ Encore une fois, pas d'inquiétude, <@DraftBot> reste français, mais pourra êt
 - Les récompenses de niveaux s'affichent à présent correctement dans le classement web.
 - Le panel pouvait parfois ne pas retrouver les messages d'un sélecteur simple, c'est corrigé.
 - Correction de la création/édition des commandes personnalisées avec conditions.
-- Correction des drop d'objets/xp/money qui pouvaient être lancés sans temps de fin.
+- Correction des drops d'objets/xp/money qui pouvaient être lancés sans temps de fin.
 - L'autocomplétion des items pouvait parfois mener à ne pas trouver les objets, c'est à présent corrigé.
 - La commande permettant la suppression des items refonctionne correctement.
 - Le renommage d'objets pouvait prendre du temps, c'est à présent instantané.

--- a/docs/3.autres/3.contribute.md
+++ b/docs/3.autres/3.contribute.md
@@ -2,7 +2,7 @@
 title: 'Page de référence'
 description: Voici la page de référence de la documentation pour l'intégration et le développement
 navigation.icon: material-symbols:edit-document-outline
-contributors: ['draftproducts', 'iibey']
+contributors: ['draftproducts', 'iibey', 'theorik']
 noindex: true
 ---
 
@@ -14,7 +14,7 @@ Voici donc quelques conseils pour améliorer votre qualité d'écriture :
 
 1. **Clarté et Concision :**
 Utilisez un vocabulaire **clair et précis**, en essayant au maximum de correspondre aux expressions de **DraftBot**. Évitez le jargon inutile et les phrases longues. **Votre objectif est de rendre l'information facilement compréhensible pour le lecteur.**
-2. **Restez bienveillants :** Evitez le plus possible les expressions subjectives comme *"simplement"*, *"juste"*, *"logiquement"*. **Gardez en tête que nous avons tous une expérience et un passé différent**. Ces mots n'apportent aucune information utile et peuvent parfois même être réducteurs et blessants, notamment pour les personnes découvrant Discord ou débutant leur utilisation avec **DraftBot**.
+2. **Restez bienveillants :** Évitez le plus possible les expressions subjectives comme *"simplement"*, *"juste"*, *"logiquement"*. **Gardez en tête que nous avons tous une expérience et un passé différent**. Ces mots n'apportent aucune information utile et peuvent parfois même être réducteurs et blessants, notamment pour les personnes découvrant Discord ou débutant leur utilisation avec **DraftBot**.
 3. **Utilisez le discours informatif :** L'intérêt de la documentation est clairement de transmettre des **informations et connaissances** concernant l'utilisation du bot. Afin de correspondre à ce discours, essayez autant que possible de **rester neutre et objectif**, sans chercher à convaincre, divertir ou imposer des choix ou actions.
 4. **Cohérence :** Gardez une cohérence dans le style, le ton, et la terminologie à travers toute la documentation. Cela aide à maintenir une expérience de lecture fluide et professionnelle. Dans ce but, employez le **vouvoiement uniquement** et essayez au maximum d'utiliser la **forme déclarative à la voix active**, au **présent** dans la majorité des cas. Des exceptions et écarts peuvent évidemment être faits selon la situation, pour revenir sur une explication passée ou aborder une possibilité à venir.
 


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page reactions-de-mots.md](https://editor.draftbot.fr?pr=164&file=docs-modules-reactions-de-mots.md)
- [Prévisualiser la page recuperer-un-identifiant.md](https://editor.draftbot.fr?pr=164&file=docs-autres-recuperer-un-identifiant.md)
- [Prévisualiser la page 2025.md](https://editor.draftbot.fr?pr=164&file=docs-autres-changelog-md)
- [Prévisualiser la page contribute.md](https://editor.draftbot.fr?pr=164&file=docs-autres-contribute.md)

## 📝 Résumé des modifications
Le résumé des changements apportés dans le diff Git est les suivants :

- Dans le fichier `docs/2.modules/14.reactions-de-mots.md`, les contributeurs ont été mis à jour en ajoutant 'theorik'.
- Dans le fichier `docs/3.autres/0.recuperer-un-identifiant.md`, les contributeurs ont été mis à jour en ajoutant 'theorik'.
- Dans le fichier `docs/3.autres/1.changelog/0.2025.md`, les contributeurs ont été mis à jour en ajoutant 'theorik'.
- Dans le fichier `docs/3.autres/3.contribute.md`, les contributeurs ont été mis à jour en ajoutant 'theorik'.

Ces changements n'ont pas eu d'impact sur le contenu réel de ces fichiers.