### PR TITLE
chore: add 2 last versions to changelog

### DIFF
--- a/docs/3.autres/1.changelog/0.2025.md
+++ b/docs/3.autres/1.changelog/0.2025.md
@@ -6,17 +6,60 @@ updatedAt: '2025-05-04'
 noindex: true
 ---
 
+## 6.0.2 - 07/05/2025
+
+[Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1369472436839649300)
+
+**Corrections**
+- Un bug introduit lors d'une optimisation interne permettait à certains membres d'exécuter plusieurs fois la commande /daily, c'est à présent corrigé.
+- Suite à l'ajout des fuseaux horaires, un délai pouvait être perçu pour l'envoi de l'annonce et l'ajout du rôle d'anniversaire.
+
+## 6.0.1 - 06/05/2025
+
+[Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1369126933920612472)
+
+**<:automod:1369109533284106260> Bloquer les messages avant leur envoi**
+
+L'une d'entre elles est l'intégration de l'auto-modération de Discord à DraftBot.
+Dans les modules de **Vocabulaire interdit** et **Mentions excessives**, il vous sera possible de bloquer les messages problématiques avant même qu'ils soient envoyés par l'utilisateur avec un petit message visible seulement par ce dernier.
+
+**<:automod_words:1369111386063372338> Module de mots interdits**
+
+Il était possible de définir un mode strict sur le module de mots interdits afin de ne bloquer que les mots exacts dans les messages.
+Afin de permettre plus de flexibilité, c'est à présent le mode par défaut pour l'ensemble des mots. Il vous sera possible d'avoir des correspondances partielles en utilisant des astérisques au début `*` et/ou à la fin de chaque mot.
+
+Dans un processus d'amélioration constant, nous avons également amélioré l'algorithme de détection des mots afin de bloquer des contournements possibles.
+Exemple : `chat*` permettra de détecter `chats`,`c h a t`, `chaaaaaats` ou `c.h.a.t`.
+
+**<:automod_markdown:1369112064043253800> Module de markdown**
+
+Un nouveau module fait son apparition parmi les modules d'auto-modération de DraftBot : Markdown
+Il vous sera possible de bloquer certains types de Markdown, exemple : `#Titres`, `-#sous-titres`, `||spoilers||`...
+
+**Corrections**
+- Un problème avec la résolution des émojis empêchait l'envoi du message des salons vocaux temporaires, ce dernier est de retour.
+- Suite à une mise à jour de notre outil de génération d'images, la commande wolfy affichait une erreur lors du chargement des images de rôles.
+- Correction de la mention dans le message de confirmation de la commande `/payer`.
+
 ## 6.0.0 - 04/05/2025
 
 [Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1368678812765786198)
 
 **<:db_EnFlag:1224123740561080424> DraftBot international !**
 
-> Une fonctionnalité attendue depuis longtemps sera bientôt disponible sur <@DraftBot>  : le choix de la langue entre le français et l'anglais, rendant le bot international !
+Une fonctionnalité attendue depuis longtemps sera bientôt disponible sur <@DraftBot>  : le choix de la langue entre le français et l'anglais, rendant le bot international !
+
 Mais avant toute chose, nous tenons à rassurer nos utilisateurs purement francophone : <@DraftBot> est et restera en Français par défaut, ainsi que son serveur Support et les membres de son équipe.
+
 Seulement, beaucoup d'utilisateurs nous ont déjà fait part de leurs besoins que le bot s'exprime en anglais sur leur serveur, et nous travaillons depuis longtemps pour satisfaire ces demandes. Dans un premier temps, pour satisfaire le plus grand nombre, nous permettons de plus en plus de personnalisations des messages envoyés par <@DraftBot>, afin qu'il s'exprime comme vous le souhaitez. Mais nous comprenons bien que pour un serveur anglophone, ce n'est pas toujours suffisant.
+
 D'ici quelques semaines, vous pourrez configurer la langue à utiliser dès les premières minutes d'utilisation du bot, et modifier votre choix si besoin dans la /config.
+
 Encore une fois, pas d'inquiétude, <@DraftBot> reste français, mais pourra être en version anglaise si besoin.
+
+**Le serveur Support et l'équipe restent en Français par défaut <:db_EnFlag:1224123740561080424>**
+
+Nous ajouterons des rôles et salons distincts pour ne pas perturber les salons en français. Nous mettrons en place la structure anglaise au fil du temps et organiserons les rôles, l'équipe, et l'assistance sur le support au fil des besoins. Les volontaires pour participer autant aux salons français qu'anglais seront les bienvenus <:db_EnFlag:1224123740561080424>
 
 ## 5.8.10 - 03/05/2025
 
@@ -183,6 +226,3 @@ Cette fonctionnalité est réservée aux serveurs <:icon_premium:109614050862512
 - Retour de la version du bot dans l'activité du bot.
 - Ajout d'une option aléatoire dans la commande \</blague>.
 - Ajout d'une variable temps dans les commandes \</dropxp>, \</dropargent> et \</dropitem> afin de pouvoir faire un drop avec une durée variable.
-
-
-


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page 2025.md](https://editor.draftbot.fr?pr=166&file=docs-autres-changelog-md)

## 📝 Résumé des modifications
Le changement apporté dans le fichier de changelog de DraftBot présente les modifications suivantes :

- Ajout d'une fonctionnalité pour choisir la langue entre le français et l'anglais, rendant DraftBot international.
- Les utilisateurs purement francophones sont assurés que DraftBot reste en français par défaut.
- Possibilité de plus en plus de personnalisations des messages envoyés par DraftBot.
- Ajout d'une variable de temps dans les commandes dropxp, dropargent et dropitem afin de pouvoir faire un drop avec une durée variable.
- Correction d'un problème avec la résolution des émojis empêchant l'envoi du message des salons vocaux temporaires.
- Correction de la mention dans le message de confirmation de la commande /payer.
- Correction d'un bug introduit lors d'une optimisation interne permettant à certains membres d'exécuter plusieurs fois la commande /daily.
- Une correction du délai pouvant être perçu pour l'envoi de l'annonce et l'ajout du rôle d'anniversaire suite à l'ajout des fuseaux horaires.
- Intégration de l'auto-modération de Discord à DraftBot, avec une option de bloquer les messages problématiques avant même qu'ils soient envoyés par l'utilisateur.
- De nouvelles fonctionnalités pour le module de mots interdits, avec une option de correspondances partielles en utilisant des astérisques, et une amélioration de l'algorithme de détection des mots.
- Un nouveau module de markdown pour bloquer certains types de Markdown.
- Retour de la version du bot dans l'activité du bot.
- Ajout d'une option aléatoire dans la commande /blague.