### PR TITLE
Modification page mise à jour : 6.0.3/4/5/6

### DIFF
--- a/docs/3.autres/1.changelog/0.2025.md
+++ b/docs/3.autres/1.changelog/0.2025.md
@@ -1,10 +1,48 @@
 ---
 title: 2025
 description: Voici la liste de tous les changements effectués, datés et décris en 2025.
-contributors: ['draftproducts', 'awakno', 'theorik']
+contributors: ['draftproducts', 'awakno', 'theorik', 'ls62']
 updatedAt: '2025-05-04'
 noindex: true
 ---
+
+## 6.0.5 - 07/05/2025
+
+**<:voice:1146811985338581142> Nouvelle option pour les salons vocaux temporaires**
+> Les membres ajoutés à la liste blanche recevraient jusqu'à présent l'ensemble des permissions configurables depuis le message de réglages (à savoir Micro, Video, Soundboard) sans moyens de modifier ce comportement. Ces permissions sont à présent configurables depuis le panel et le /config.
+
+**⌛ Problèmes de latence**
+> Nombreux parmi vous avaient été touchés par des problèmes de latence.
+La source du problème a été identifiée et corrigée.
+
+**✨ Améliorations**
+- Un bouton "Aller au message" a été ajouté sur les messages de starboards.
+- Les erreurs liées aux envois de messages depuis le panel avec des profils ont été affinées et rendues plus claires.
+- La commande de statistiques Clash of Clans a été mise à jour avec les dernières troupes sorties.
+
+**<:icon_bugHunter:759790785780252693> Corrections**
+- L'âge était parfois mal affiché, cela a été corrigé.
+- Plusieurs bugs présents dans le /config des niveaux et d'économie ont été corrigés.
+- Les icones du message de réglages des salons vocaux temporaires s'affichent à présent correctement en langue anglaise.
+- La liste des commandes s'affiche à présent correctement en anglais sur le panel.
+
+[Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1373168299432607804)
+
+**Corrections**
+- Un bug introduit lors d'une optimisation interne permettait à certains membres d'exécuter plusieurs fois la commande /daily, c'est à présent corrigé.
+- Suite à l'ajout des fuseaux horaires, un délai pouvait être perçu pour l'envoi de l'annonce et l'ajout du rôle d'anniversaire.
+
+## 6.0.3
+
+**Amélioration**
+- Un bouton "Aller au message" a été ajouté sur les messages de starboards.
+- Les erreurs liées aux envois de messages depuis le panel avec des profils ont été affinées et rendues plus claires.
+-
+
+**Correction**
+- La liste des commandes s'affiche à présent correctement en anglais sur le panel.
+
+- La commande de statistiques Clash of Clans a été mise à jour avec les dernières troupes sorties.
 
 ## 6.0.2 - 07/05/2025
 

--- a/docs/3.autres/1.changelog/0.2025.md
+++ b/docs/3.autres/1.changelog/0.2025.md
@@ -6,7 +6,14 @@ updatedAt: '2025-05-04'
 noindex: true
 ---
 
-## 6.0.5 - 07/05/2025
+
+## 6.0.6 - 24/05/2025
+**Correction**
+- Les annonces des anniversaires privés ont été corrigées.
+
+## 6.0.5 - 17/05/2025
+
+[Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1373168299432607804)
 
 **<:voice:1146811985338581142> Nouvelle option pour les salons vocaux temporaires**
 > Les membres ajoutés à la liste blanche recevraient jusqu'à présent l'ensemble des permissions configurables depuis le message de réglages (à savoir Micro, Video, Soundboard) sans moyens de modifier ce comportement. Ces permissions sont à présent configurables depuis le panel et le /config.
@@ -26,20 +33,32 @@ La source du problème a été identifiée et corrigée.
 - Les icones du message de réglages des salons vocaux temporaires s'affichent à présent correctement en langue anglaise.
 - La liste des commandes s'affiche à présent correctement en anglais sur le panel.
 
-[Lien du message](https://discord.com/channels/422112414964908042/599942732559024138/1373168299432607804)
-
 **Corrections**
 - Un bug introduit lors d'une optimisation interne permettait à certains membres d'exécuter plusieurs fois la commande /daily, c'est à présent corrigé.
 - Suite à l'ajout des fuseaux horaires, un délai pouvait être perçu pour l'envoi de l'annonce et l'ajout du rôle d'anniversaire.
 
-## 6.0.3
+## 6.0.4 - 16/05/2025
 
-**Amélioration**
+**Améliorations**
+- La commande de statistiques Clash of Clans a été mise à jour avec les dernières troupes sorties.
+- L'âge était parfois mal affiché, cela a été corrigé.
+- Les icones du message de réglages des salons vocaux temporaires s'affichent à présent correctement en langue anglaise.
+
+**Corrections**
+- La liste des commandes s'affiche à présent correctement en anglais sur le panel.
+- Un souci d'affichage de texte dans la commande \</conversation enregistrer> a été corrigé.
+- Les icones du message de réglages des salons vocaux temporaires s'affichent à présent correctement en langue anglaise.
+- Plusieurs bugs présents dans le /config des niveaux et d'économie ont été corrigés.
+
+## 6.0.3 - 12/05/2025
+
+**Améliorations**
 - Un bouton "Aller au message" a été ajouté sur les messages de starboards.
 - Les erreurs liées aux envois de messages depuis le panel avec des profils ont été affinées et rendues plus claires.
--
+- Les fuseaux horaires des messages récurrents ont été optimisés.
+- Certains mots en anglais ont été améliorés.
 
-**Correction**
+**Corrections**
 - La liste des commandes s'affiche à présent correctement en anglais sur le panel.
 
 - La commande de statistiques Clash of Clans a été mise à jour avec les dernières troupes sorties.


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page 2025.md](https://editor.draftbot.fr?pr=179&file=docs-autres-changelog-md)

## 📝 Résumé des modifications
Voici un résumé concis des changements apportés dans la version 6.0.6 du 24/05/2025 :
- Correction des annonces des anniversaires privés
- Ajout d'une option pour les salons vocaux temporaires pour permettre la configuration de permissions
- Correction des problèmes de latence
- Ajout d'un bouton "Aller au message" sur les messages de starboards
- Amélioration de la clarté des erreurs liées aux envois de messages depuis le panel avec des profils
- Mise à jour de la commande de statistiques Clash of Clans avec les dernières troupes sorties
- Correction d'icones de message de réglages des salons vocaux temporaires en langue anglaise
- Correction de plusieurs bugs présents dans le /config des niveaux et d'économie
- Correction d'un souci d'affichage de texte dans la commande \</conversation enregistrer>
- Correction des icones du message de réglages des salons vocaux temporaires en langue anglaise
- Correction d'un bug introduit lors d'une optimisation interne pour permettre le seul exécution de la commande /daily une seule fois
- Optimisation des fuseaux horaires des messages récurrents
- Amélioration de certains mots en anglais.