### PR TITLE
Ajout de zefzef

### DIFF
--- a/docs/2.modules/29.zefzef.md
+++ b/docs/2.modules/29.zefzef.md
@@ -1,0 +1,7 @@
+---
+title: zefzef
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['draftproducts']
+updatedAt: '2025-08-01'
+---

--- a/docs/2.modules/30.popopo.md
+++ b/docs/2.modules/30.popopo.md
@@ -1,0 +1,7 @@
+---
+title: POPOPO
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['draftproducts']
+updatedAt: '2025-08-01'
+---

--- a/docs/2.modules/31.zefzefzefzefzefzefzefzefezf.md
+++ b/docs/2.modules/31.zefzefzefzefzefzefzefzefezf.md
@@ -1,0 +1,7 @@
+---
+title: zefzefzefzefzefzefzefzefezf
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['draftproducts']
+updatedAt: '2025-08-01'
+---

--- a/docs/2.modules/32.zefzefzf.md
+++ b/docs/2.modules/32.zefzefzf.md
@@ -1,0 +1,7 @@
+---
+title: zefzefzf
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['draftproducts']
+updatedAt: '2025-08-01'
+---

--- a/docs/2.modules/33.zefzefzfzefzfe.md
+++ b/docs/2.modules/33.zefzefzfzefzfe.md
@@ -1,0 +1,7 @@
+---
+title: zefzefzfzefzfe
+description:
+navigation.icon: 'twemoji:memo'
+contributors: ['draftproducts']
+updatedAt: '2025-08-01'
+---


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page zefzef.md](https://editor.draftbot.fr?pr=194&file=docs-modules-zefzef.md)

## 📝 Résumé des modifications
Le document Markdown `docs/2.modules/29.zefzef.md` a été créé par draftproducts le 1er août 2025. Il s'agit d'un document intitulé « zefzef » et apparait dans la navigation avec un icône ressemblant à un livre. La description de ce document n'est pas précisée.