### PR TITLE
Amélioration de la page Modération

### DIFF
--- a/docs/2.modules/25.auto-moderation.md
+++ b/docs/2.modules/25.auto-moderation.md
@@ -2,13 +2,13 @@
 title: Auto-Modération
 description: L'auto-modération bloque les mauvais comportements tels que les spams, les publicités ou encore les insultes, et les sanctionne, le tout sans intervention de votre part.
 navigation.icon: 'twemoji:shield'
-contributors: ['rababio4579', 'kicoulapic314']
+contributors: ['rababio4579', 'kicoulapic314', 'draftproducts']
 updatedAt: '2025-02-14'
 ---
 
 ## Détection d'infractions
 
-Le système de détection d'infractions permet d'empêcher les mauvais comportements.
+Les **infractions** correspondent à un déclenchement de l'auto-modération : envoi d'un mot interdit, d'un lien interdit, etc. Les [**sanctions**](#sanctions-automatiques) correspondent aux actions de modération : avertissement du membre, exclusion, bannissement, etc.
 
 ::tabs
   ::tab{ label="Via la commande /config" }
@@ -40,9 +40,17 @@ Le système de détection d'infractions permet d'empêcher les mauvais comportem
   ::
 ::
 
-### Modules
+Tous les modules incluent ces options vous permettant de les configurer avec granularité :
 
-#### Vocabulaire interdit
+- **Mode silencieux** : Si activé, DraftBot ne répondra pas à l'infraction par un message explicatif.
+- **Salons ignorés** : Salons dans lesquels l'auto-modération est désactivé.
+- **Rôles ignorés** : Rôles ignorés par l'auto-modération.
+
+::hint{ type="info" }  Les **administrateurs** ainsi que les autres **bots** du serveur sont
+  automatiquement ignorés par auto-modération.
+::
+
+### Vocabulaire interdit
 
 Vous pouvez choisir des expressions (mots) qui seront bloquées par DraftBot.
 
@@ -50,9 +58,13 @@ Ajouter un ``*`` au début et/ou à la fin du mot permet de bloquer les mots ave
 
 - L'option **blocage des messages** permet de bloquer les messages avant leur envoi grâce au système d'AutoMod Discord <:automod:1369109533284106260> tout en comptabilisant l'infraction dans l'historique du membre.
 
-- Si l'option **censure** est activée, DraftBot renverra le message bloqué via un webhook avec le nom de l’utilisateur, sa photo de profil et l'expression censurée.
+- Si l'option **censure** est activée, DraftBot renverra le message bloqué via un webhook avec le nom de l'utilisateur, sa photo de profil et l'expression censurée.
 
-#### Invitations Discord
+::hint{ type="warning" }
+  L'option **blocage des messages** ne prend en charge que les **1000 premiers mots** configurés en raison d'une limitation de Discord.
+::
+
+### Invitations Discord
 
 Ce module permet d'interdire la publication de liens d'invitations dans les salons de votre serveur (les invitations vers votre serveur ne sont pas bloquées).
 
@@ -64,17 +76,21 @@ Ce module permet d'interdire la publication de liens d'invitations dans les salo
   Cette option est une fonctionnalité réservée aux serveurs [premium](/premium) <:icon_premium_:1096140508625125417>.
 ::
 
-- Si l'option **censure** est activée, DraftBot renverra le message via un webhook avec le nom de l’utilisateur, sa photo de profil et le lien d'invitation censuré.
+- Si l'option **censure** est activée, DraftBot renverra le message via un webhook avec le nom de l'utilisateur, sa photo de profil et le lien d'invitation censuré.
 
-#### Liens externes
+::hint{ type="info" }
+  Toutes les invitations sont analysées, celles qui mènent à votre serveur ou à un salon vocal de votre serveur sont automatiquement ignorées.
+::
+
+### Liens externes
 
 Ce module permet d'interdire la publication de liens sur votre serveur.
 
 - L'option **noms de domaine autorisés/interdits** permet d'interdire ou d'ignorer uniquement certains liens (sélectionnez le mode adapté) en précisant le nom de domaine ; par exemple `draftbot.fr`.
 
-- Si l'option **censure** est activée, DraftBot renverra le message via un webhook avec le nom de l’utilisateur, sa photo de profil et le lien censuré.
+- Si l'option **censure** est activée, DraftBot renverra le message via un webhook avec le nom de l'utilisateur, sa photo de profil et le lien censuré.
 
-#### Majuscules excessives
+### Majuscules excessives
 
 Ce module permet de limiter la quantité de majuscules dans les messages.
 
@@ -82,7 +98,7 @@ Ce module permet de limiter la quantité de majuscules dans les messages.
 
 - Le **nombre de caractères minimum** est le nombre minimal de caractères que doit comporter un message pour que l'auto-modération le prenne en compte.
 
-#### Émojis excessifs
+### Émojis excessifs
 
 Ce module permet de limiter l'utilisation des émojis dans les messages.
 
@@ -90,7 +106,7 @@ Ce module permet de limiter l'utilisation des émojis dans les messages.
 
 - Le **nombre d'émojis maximum** est le nombre maximal d'émojis qu'un message peut comporter.
 
-#### Pings interdits
+### Pings interdits
 
 Ce module permet d'interdire la mention de certains membres ou rôles spécifiques.
 
@@ -98,7 +114,7 @@ Sélectionnez les mentions que vous souhaitez interdire dans le champ **membres 
 
 - L'option **blocage des messages** permet de bloquer les messages contenant la mention interdite avant leur envoi, grâce au système d'AutoMod Discord <:automod:1369109533284106260>, tout en comptabilisant l'infraction dans l'historique du membre.
 
-#### Mentions excessives
+### Mentions excessives
 
 Ce module permet d'empêcher le spam de mentions.
 
@@ -118,7 +134,7 @@ Ce module permet d'empêcher le spam de mentions.
   Le comptage des mentions est indépendant pour chaque membre.
 ::
 
-#### Spam de messages
+### Spam de messages
 
 Ce module permet d'empêcher le spam de messages.
 
@@ -130,7 +146,7 @@ Ce module permet d'empêcher le spam de messages.
   Le comptage de messages est indépendant pour chaque membre.
 ::
 
-#### Markdown interdit
+### Markdown interdit
 
 Ce module vous permet de bloquer l'utilisation des markdowns de votre choix parmi :
 - Code en bloc
@@ -148,17 +164,9 @@ Si la **suppression du markdown** est activée, DraftBot renverra le message blo
   Retrouvez les détails des différents markdowns sur [cette page](/docs/autres/markdown).
 ::
 
-### Options récurrentes
-
-- **Mode silencieux** : Si activé, DraftBot ne répondra pas à l'infraction par un message explicatif.
-- **Salons ignorés** : Salons dans lesquels l'auto-modération est inactive.
-- **Rôles ignorés** : Rôles ignorés par l'auto-modération.
-
 ## Sanctions automatiques
 
-Les sanctions automatiques permettent d'appliquer automatiquement des actions de modération aux membres après une quantité définie d'infractions.
-
-### Configuration
+Les sanctions automatiques permettent d'appliquer automatiquement des actions de modération aux membres après une quantité définie d'[**infractions**](#détection-dinfractions).
 
 ::tabs
   ::tab{ label="Via la commande /config" }
@@ -182,8 +190,6 @@ Les sanctions automatiques permettent d'appliquer automatiquement des actions de
   ::
 ::
 
-### Options disponibles
-
 - **Sanction** : Le type de sanction à appliquer lors du déclenchement de l'automatisation de la sanction (avertissement par exemple).
 - **Nombre d'infractions** : Une fois ce nombre d'infractions atteint, la sanction automatique est appliquée.
 
@@ -194,14 +200,7 @@ Les sanctions automatiques permettent d'appliquer automatiquement des actions de
 - **Infraction** : Définir quel type d'infraction sera comptabilisé pour la sanction automatique.
 - **Intervalle de temps** : La sanction automatique se déclenche si le nombre d'infractions défini précédemment est atteint durant cet intervalle de temps.
 
-::hint{ type="warning" }
-  Les **infractions** correspondent à un déclenchement de l'auto-modération : envoi d'un mot interdit, d'un lien interdit, etc. Les **sanctions** correspondent aux actions de modération : avertissement du membre, exclusion, bannissement, etc.
-::
-
-::hint{ type="info" }
-  Une fois la sanction automatique enregistrée, une phrase complète la décrira pour une compréhension plus simple.
-::
-
 ::hint{ type="info" }
   Vous pouvez configurer jusqu'à 10 sanctions automatiques. Les serveurs [premium](/premium) <:icon_premium_:1096140508625125417> peuvent en avoir 50.
 ::
+

--- a/docs/2.modules/25.auto-moderation.md
+++ b/docs/2.modules/25.auto-moderation.md
@@ -40,7 +40,7 @@ Les **infractions** correspondent à un déclenchement de l'auto-modération : e
   ::
 ::
 
-Tous les modules incluent ces options vous permettant de les configurer indépendamment :
+Tous les modules incluent ces options, permettant de les configurer indépendamment :
 
 - **Mode silencieux** : Si activé, DraftBot ne répondra pas à l'infraction par un message explicatif.
 - **Salons ignorés** : Salons dans lesquels l'auto-modération est désactivée.

--- a/docs/2.modules/25.auto-moderation.md
+++ b/docs/2.modules/25.auto-moderation.md
@@ -40,14 +40,14 @@ Les **infractions** correspondent à un déclenchement de l'auto-modération : e
   ::
 ::
 
-Tous les modules incluent ces options vous permettant de les configurer avec granularité :
+Tous les modules incluent ces options vous permettant de les configurer indépendamment :
 
 - **Mode silencieux** : Si activé, DraftBot ne répondra pas à l'infraction par un message explicatif.
-- **Salons ignorés** : Salons dans lesquels l'auto-modération est désactivé.
+- **Salons ignorés** : Salons dans lesquels l'auto-modération est désactivée.
 - **Rôles ignorés** : Rôles ignorés par l'auto-modération.
 
-::hint{ type="info" }  Les **administrateurs** ainsi que les autres **bots** du serveur sont
-  automatiquement ignorés par auto-modération.
+::hint{ type="info" }
+  Les **administrateurs** ainsi que les autres **bots** du serveur sont automatiquement ignorés par l'auto-modération.
 ::
 
 ### Vocabulaire interdit
@@ -56,13 +56,13 @@ Vous pouvez choisir des expressions (mots) qui seront bloquées par DraftBot.
 
 Ajouter un ``*`` au début et/ou à la fin du mot permet de bloquer les mots avec une correspondance partielle : `chat*` permettra de détecter `chats`, `c h a t`, `chaaaaaat` ou `c.h.a.t`.
 
-- L'option **blocage des messages** permet de bloquer les messages avant leur envoi grâce au système d'AutoMod Discord <:automod:1369109533284106260> tout en comptabilisant l'infraction dans l'historique du membre.
-
-- Si l'option **censure** est activée, DraftBot renverra le message bloqué via un webhook avec le nom de l'utilisateur, sa photo de profil et l'expression censurée.
+- L'option **blocage des messages** permet de bloquer les messages avant leur envoi, grâce au système d'AutoMod Discord <:automod:1369109533284106260> tout en comptabilisant l'infraction dans l'historique du membre.
 
 ::hint{ type="warning" }
-  L'option **blocage des messages** ne prend en charge que les **1000 premiers mots** configurés en raison d'une limitation de Discord.
+  Seul les **1000 premiers mots** sont pris en charge en raison d'une limitation de Discord.
 ::
+
+- Si l'option **censure** est activée, DraftBot renverra le message bloqué via un webhook avec le nom de l'utilisateur, sa photo de profil et l'expression censurée.
 
 ### Invitations Discord
 
@@ -86,7 +86,7 @@ Ce module permet d'interdire la publication de liens d'invitations dans les salo
 
 Ce module permet d'interdire la publication de liens sur votre serveur.
 
-- L'option **noms de domaine autorisés/interdits** permet d'interdire ou d'ignorer uniquement certains liens (sélectionnez le mode adapté) en précisant le nom de domaine ; par exemple `draftbot.fr`.
+- L'option **noms de domaine autorisés/interdits** permet d'interdire ou d'ignorer uniquement certains liens en précisant le nom de domaine ; par exemple `draftbot.fr`.
 
 - Si l'option **censure** est activée, DraftBot renverra le message via un webhook avec le nom de l'utilisateur, sa photo de profil et le lien censuré.
 
@@ -104,7 +104,7 @@ Ce module permet de limiter l'utilisation des émojis dans les messages.
 
 - Le **pourcentage d'émojis du message** correspond au pourcentage minimal d'émojis que doit contenir un message pour que l'auto-modération le prenne en compte.
 
-- Le **nombre d'émojis maximum** est le nombre maximal d'émojis qu'un message peut comporter.
+- Le **nombre d'émojis minimum** est le nombre minimal d'émojis que doit comporter un message pour que l'auto-modération le prenne en compte.
 
 ### Pings interdits
 
@@ -203,4 +203,5 @@ Les sanctions automatiques permettent d'appliquer automatiquement des actions de
 ::hint{ type="info" }
   Vous pouvez configurer jusqu'à 10 sanctions automatiques. Les serveurs [premium](/premium) <:icon_premium_:1096140508625125417> peuvent en avoir 50.
 ::
+
 


### PR DESCRIPTION
## 🔍 Prévisualisation
- [Prévisualiser la page auto-moderation.md](https://editor.draftbot.fr?pr=202&file=docs-modules-auto-moderation.md)

## 📝 Résumé des modifications
Le changement apporté consiste à ajouter le contributeur 'draftproducts' à la liste des contributeurs du fichier markdown sur l'auto-modération. Il y a également des modifications sur la détection d'infractions et la censure, ainsi que sur les modules de vocabulaire interdit, d'invitations Discord, de liens externes, de majuscules excessives, d'émojis excessifs, de pings interdits, de spam de messages, de markdown interdit et des sanctions automatiques.